### PR TITLE
✨ Add manual release workflow for UI-based publishing

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -1,0 +1,130 @@
+name: 📦 Manual Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version_type:
+        description: 'Version bump type'
+        required: true
+        default: 'patch'
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+      release_notes:
+        description: 'Release notes (optional)'
+        required: false
+        type: string
+        default: ''
+
+jobs:
+  release:
+    name: Create Release & Publish to NPM
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+    
+    steps:
+      - name: 📦 Checkout code
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+          
+      - name: 📋 Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+          
+      - name: 📥 Install dependencies
+        run: npm ci
+        
+      - name: 🧪 Run tests
+        run: npm test
+        
+      - name: 🔨 Build package
+        run: npm run build
+        
+      - name: 🏷️ Configure git
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          
+      - name: 📈 Bump version
+        id: version
+        run: |
+          NEW_VERSION=$(npm version ${{ inputs.version_type }} --no-git-tag-version)
+          echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
+          echo "version_number=${NEW_VERSION#v}" >> $GITHUB_OUTPUT
+          
+      - name: 📝 Update package.json in git
+        run: |
+          git add package.json
+          git commit -m "🔖 Bump version to ${{ steps.version.outputs.new_version }}"
+          
+      - name: 🏷️ Create and push tag
+        run: |
+          git tag ${{ steps.version.outputs.new_version }}
+          git push origin main
+          git push origin ${{ steps.version.outputs.new_version }}
+          
+      - name: 🚀 Publish to NPM
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          
+      - name: 📋 Generate release notes
+        id: release_notes
+        run: |
+          if [ -n "${{ inputs.release_notes }}" ]; then
+            NOTES="${{ inputs.release_notes }}"
+          else
+            # Auto-generate release notes from recent commits
+            NOTES=$(git log --oneline $(git describe --tags --abbrev=0 HEAD~1)..HEAD --pretty=format:"- %s" | head -10)
+            if [ -z "$NOTES" ]; then
+              NOTES="- Version bump to ${{ steps.version.outputs.new_version }}"
+            fi
+          fi
+          
+          # Escape newlines for GitHub output
+          echo "notes<<EOF" >> $GITHUB_OUTPUT
+          echo "$NOTES" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+          
+      - name: 🎉 Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ steps.version.outputs.new_version }}
+          name: 🚀 Release ${{ steps.version.outputs.new_version }}
+          body: |
+            ## 🎉 New Release: ${{ steps.version.outputs.new_version }}
+            
+            **Published to NPM**: https://www.npmjs.com/package/@georgevie/period-sequence@${{ steps.version.outputs.version_number }}
+            
+            ### Changes
+            ${{ steps.release_notes.outputs.notes }}
+            
+            ### Installation
+            ```bash
+            npm install @georgevie/period-sequence@${{ steps.version.outputs.version_number }}
+            ```
+            
+            ### Quick Start
+            ```typescript
+            import { Period, Sequence } from '@georgevie/period-sequence';
+            
+            const meeting = Period.fromDates(new Date('2024-01-15T09:00:00Z'), new Date('2024-01-15T10:00:00Z'));
+            const today = Period.today();
+            const sequence = new Sequence(meeting, today);
+            ```
+          draft: false
+          prerelease: false
+          
+      - name: ✅ Release Summary
+        run: |
+          echo "🎉 Successfully released ${{ steps.version.outputs.new_version }}!"
+          echo "📦 NPM: https://www.npmjs.com/package/@georgevie/period-sequence"
+          echo "🏷️ GitHub: https://github.com/${{ github.repository }}/releases/tag/${{ steps.version.outputs.new_version }}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,11 @@
-name: 🚀 Publish to NPM
+name: 🚀 Auto Publish to NPM
 
 on:
   push:
     tags:
       - 'v*'  # Trigger on version tags like v1.0.1, v2.0.0, etc.
+      # Note: This workflow runs when tags are pushed manually
+      # For UI-based releases, use the "Manual Release" workflow instead
 
 jobs:
   publish:


### PR DESCRIPTION
🎯 New Features:
- Manual GitHub Action workflow triggered from GitHub UI
- Choose version bump type: patch/minor/major via dropdown
- Optional custom release notes input
- Automatic version bumping and git tagging
- Auto-publishes to NPM after tests pass
- Creates GitHub release with generated/custom notes

🚀 Usage:
1. Go to GitHub Actions tab
2. Select 'Manual Release' workflow
3. Click 'Run workflow'
4. Choose version type & add notes
5. Everything else is automated!

✅ Much easier than manual command line releases
✅ Maintains all safety checks (tests must pass)
✅ Both manual and auto workflows available